### PR TITLE
fix incrementing file numbers

### DIFF
--- a/matrix_photos/storage_strategy.py
+++ b/matrix_photos/storage_strategy.py
@@ -36,10 +36,12 @@ class DefaultStorageStrategy():
             text_file.writelines(new_data)
 
     def _get_next_filename(self, prefered_filename: str, index: int = 0) -> str:
-        suffix = f" #{index}" if index > 0 else ''
-        new_filename = f'{prefered_filename}{suffix}'
-        if os.path.exists(new_filename):
-            return self._get_next_filename(prefered_filename, index+1)
+        (base, ext) = os.path.splitext(prefered_filename)
+        new_filename = prefered_filename
+        index = 1
+        while os.path.exists(new_filename):
+            new_filename = f'{base}#{index}{ext}'
+            index += 1
         return new_filename
 
     def _convert_file(self, filename: str):


### PR DESCRIPTION
Hi, I had some issues when files were renamed to include an index. The old code did not consider the file extension when adding the index, like `image02939.jpg #1` instead of `image02939 #1.jpg`.