### PR TITLE
use correct parameters when calling convert

### DIFF
--- a/matrix_photos/text_message_command_handler.py
+++ b/matrix_photos/text_message_command_handler.py
@@ -26,7 +26,7 @@ class TextmessageCommandHandler:
     def _add_message_to_file(self, filename, message):
         self.log.trace(f'_add_text_to_file {message}')
         self._convert.convert_file(filename,
-                                   self._config.convert.convert_parameters,
+                                   self._config.message_convert.convert_parameters,
                                    message=message,
                                    convert_text_parameter=self._config.message_convert.convert_text_parameter
                                    )


### PR DESCRIPTION
The config file contains an extra section with parameters for using convert to add textmessages to images.
We have to use this section.
